### PR TITLE
Show leaderboard in proper order

### DIFF
--- a/app/templates/support.html
+++ b/app/templates/support.html
@@ -71,7 +71,7 @@
         <script>
         $(document).ready(function() {
             $("#sortTable").DataTable({
-            "order": [[ 2, "desc" ]]
+            "order": [[ 2, "asc" ]]
             });
         });
         </script>


### PR DESCRIPTION
The "rankings" should go in ascending order, even if their equivalent ETH stakes should be in descending order.
To be honest I didn't even test this, it may not work like that. But, if you know...
Closes #70 